### PR TITLE
Removed dependency on ptools (breaks Origen for Windows)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     origen_memory_image (0.6.1)
       origen (>= 0.2.2)
-      ptools (~> 1)
 
 GEM
   remote: https://rubygems.org/
@@ -63,6 +62,8 @@ GEM
     net-ldap (0.16.0)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.6.7.2-x64-mingw32)
+      mini_portile2 (~> 2.0.0.rc2)
     origen (0.7.45)
       activesupport (~> 4.1)
       bundler (~> 1.7)
@@ -95,7 +96,6 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    ptools (1.3.3)
     rack (1.6.5)
     rack-protection (1.5.3)
       rack
@@ -146,6 +146,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   byebug (~> 3.5)
@@ -154,4 +155,4 @@ DEPENDENCIES
   origen_memory_image!
 
 BUNDLED WITH
-   1.13.6
+   1.15.0

--- a/lib/origen_memory_image/binary.rb
+++ b/lib/origen_memory_image/binary.rb
@@ -4,10 +4,9 @@ module OrigenMemoryImage
       if snippet
         file.all? { |l| l.strip =~ /^[01]*$/ }
       else
-        # Replicated the relevant code from the ptools GEM to detect a binary file
-        s = (File.read(file, 4096) || '')
-        s = s.encode('US-ASCII', undef: :replace).split(//)
-        ((s.size - s.grep(' '..'~').size) / s.size.to_f) > 0.3
+        # detect whether the data is mostly not alpha numeric
+        filedata = (File.read(file, 256) || '')
+        (filedata.gsub(/\s+/, '').gsub(/\w/, '').length.to_f / filedata.length.to_f) > 0.3
       end
     end
 

--- a/lib/origen_memory_image/binary.rb
+++ b/lib/origen_memory_image/binary.rb
@@ -1,12 +1,13 @@
-require 'ptools'
-
 module OrigenMemoryImage
   class Binary < Base
     def self.match?(file, snippet = false)
       if snippet
         file.all? { |l| l.strip =~ /^[01]*$/ }
       else
-        File.binary?(file)
+        # Replicated the relevant code from the ptools GEM to detect a binary file
+        s = (File.read(file, 4096) || '')
+        s = s.encode('US-ASCII', undef: :replace).split(//)
+        ((s.size - s.grep(' '..'~').size) / s.size.to_f) > 0.3
       end
     end
 

--- a/origen_memory_image.gemspec
+++ b/origen_memory_image.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
 
   # Add any gems that your plugin needs to run within a host application
   spec.add_runtime_dependency "origen", ">= 0.2.2"
-  spec.add_runtime_dependency "ptools", "~>1"
 
   # Add any gems that your plugin needs for its development environment only
   spec.add_development_dependency "origen_doc_helpers", ">= 0.2.0"


### PR DESCRIPTION
The ptools GEM causes File.basepath to behave differently in Windows which causes a run time error when Origen creates output files.  Since ptools was only being used to detect whether or not a file is a binary file, it makes sense to simply remove this dependency.  This PR does just that.